### PR TITLE
fix: mobile url fragment link location

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ const HomePage = (props: Props) => {
   const aboutScrollToRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="h-screen overflow-y-auto overflow-x-hidden pt-24 lg:snap-y lg:snap-mandatory xl:scrollbar xl:scrollbar-track-neutral-900/80 xl:scrollbar-thumb-neutral-50/30">
+    <div className="h-screen scroll-pt-24 overflow-y-auto overflow-x-hidden pt-24 lg:snap-y lg:snap-mandatory lg:scroll-pt-0 xl:scrollbar xl:scrollbar-track-neutral-900/80 xl:scrollbar-thumb-neutral-50/30">
       <Hero scrollToRef={aboutScrollToRef} />
       <div ref={aboutScrollToRef}>
         <About />


### PR DESCRIPTION
The solution was to add `scroll-pt-24` because the header had `h-24` and was `fixed`, so needed to push the scroll down by `h-24` to make sure url fragments properly linked to the start of the section.